### PR TITLE
Make plugin possible to be installed with SymfonyFlex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "sylius/customer-reorder-plugin",
-    "type": "sylius-plugin",
+    "type": "symfony-bundle",
+    "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "customer reorder"],
     "description": "Sylius plugin that enables order reordering for a customer",
     "license": "MIT",
     "authors": [
@@ -12,8 +13,7 @@
     "require": {
         "php": "^7.2",
 
-        "sylius/sylius": "~1.3.0",
-        "symfony/symfony": "^3.4|^4.1"
+        "sylius/sylius": "~1.3.0"
     },
     "require-dev": {
         "behat/behat": "^3.4",
@@ -30,7 +30,13 @@
         "phpspec/phpspec": "^4.0",
         "phpstan/phpstan-shim": "^0.9.2",
         "phpunit/phpunit": "^6.5",
-        "sylius-labs/coding-standard": "^2.0"
+        "sylius-labs/coding-standard": "^2.0",
+        "symfony/browser-kit": "^3.4|^4.1",
+        "symfony/debug-bundle": "^3.4|^4.1",
+        "symfony/dotenv": "^3.4|^4.1",
+        "symfony/intl": "^3.4|^4.1",
+        "symfony/web-profiler-bundle": "^3.4|^4.1",
+        "symfony/web-server-bundle": "^3.4|^4.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Following an approach proposed in https://github.com/Sylius/RefundPlugin/pull/69 and in https://github.com/Sylius/PluginSkeleton/pull/123/files