### PR TITLE
Bring back "sylius-plugin" composer type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sylius/customer-reorder-plugin",
-    "type": "symfony-bundle",
+    "type": "sylius-plugin",
     "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "customer reorder"],
     "description": "Sylius plugin that enables order reordering for a customer",
     "license": "MIT",


### PR DESCRIPTION
**SymfonyFlex** has now support for `sylius-plugin` as a synonymous of `symfony-bundle` :)