### PR TITLE
Fix crash when returning a non string value

### DIFF
--- a/src/ReorderEligibility/ReorderEligibilityConstraintMessageFormatter.php
+++ b/src/ReorderEligibility/ReorderEligibilityConstraintMessageFormatter.php
@@ -13,7 +13,7 @@ final class ReorderEligibilityConstraintMessageFormatter implements ReorderEligi
         if (count($messageParameters) === 1) {
             $message = array_pop($messageParameters);
 
-            return $message;
+            return (string) $message;
         }
 
         $lastMessageParameter = end($messageParameters);


### PR DESCRIPTION
Fix a crash caused by a strict return type (string) which can occurs when an argument is an integer.
This argument can be an integer if the product name is composed of number only. It is casted to an integer because it is used as an array key when building the format's arguments.